### PR TITLE
Fix readme's declaration of galleryHelper's getFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ galleryHelper.dispatchGalleryIntent();
     super.onActivityResult(requestCode, resultCode, data);
 
     if (requestCode == GalleryHelper.PICK_IMAGE_REQUEST) {
-      System.out.println(galleryHelper.getFile(resultCode));
+      System.out.println(galleryHelper.getFile(resultCode, data));
     }
   }
 ```


### PR DESCRIPTION
### Summary
Updated Readme to reflect new implementation of galleryHelper's 'getFile' method.
