### PR TITLE
Runtime Permission for CameraHelper

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -13,7 +13,7 @@ android {
     applicationId "com.ibm.watson.developer_cloud.android.myapplication"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     minSdkVersion 9
-    targetSdkVersion 21
+    targetSdkVersion 23
     versionCode 1
     versionName "1.0"
 

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -7,10 +7,9 @@
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.MANAGE_DOCUMENTS"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.CAMERA" />
 
-  <uses-feature
-      android:name="android.hardware.camera"
-      android:required="false"/>
+  <uses-feature android:name="android.hardware.camera" />
 
   <application
       android:name="android.support.multidex.MultiDexApplication"

--- a/example/src/main/java/com/ibm/watson/developer_cloud/android/myapplication/MainActivity.java
+++ b/example/src/main/java/com/ibm/watson/developer_cloud/android/myapplication/MainActivity.java
@@ -17,6 +17,7 @@
 package com.ibm.watson.developer_cloud.android.myapplication;
 
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -305,7 +306,19 @@ public class MainActivity extends AppCompatActivity {
 
     @Override protected String doInBackground(String... params) {
       player.playStream(textService.synthesize(params[0], Voice.EN_LISA));
-      return "Did syntesize";
+      return "Did synthesize";
+    }
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    switch (requestCode) {
+      case CameraHelper.REQUEST_PERMISSION: {
+        // permission granted
+        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+          cameraHelper.dispatchTakePictureIntent();
+        }
+      }
     }
   }
 

--- a/library/src/main/java/com/ibm/watson/developer_cloud/android/library/camera/CameraHelper.java
+++ b/library/src/main/java/com/ibm/watson/developer_cloud/android/library/camera/CameraHelper.java
@@ -2,11 +2,14 @@ package com.ibm.watson.developer_cloud.android.library.camera;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -18,6 +21,7 @@ public final class CameraHelper {
 
   private final String TAG = CameraHelper.class.getName();
   public static final int REQUEST_IMAGE_CAPTURE = 1000;
+  public static final int REQUEST_PERMISSION = 3000;
 
   private Activity activity;
   private String currentPhotoPath;
@@ -34,23 +38,41 @@ public final class CameraHelper {
    * Starts an activity using the device's onboard camera app
    */
   public void dispatchTakePictureIntent() {
-    Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-    // Ensure that there's a camera activity to handle the intent
-    if (takePictureIntent.resolveActivity(activity.getPackageManager()) != null) {
-      // Create the File where the photo should go
-      File photoFile = null;
-      try {
-        photoFile = createImageFile();
-      } catch (IOException ex) {
-        Log.e(TAG, "IOException", ex);
-      }
-      // Continue only if the File was successfully created
-      if (photoFile != null) {
-        takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT,
-            Uri.fromFile(photoFile));
-        activity.startActivityForResult(takePictureIntent, REQUEST_IMAGE_CAPTURE);
+    if (checkPermissions()) {
+      Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+      // Ensure that there's a camera activity to handle the intent
+      if (takePictureIntent.resolveActivity(activity.getPackageManager()) != null) {
+        // Create the File where the photo should go
+        File photoFile = null;
+        try {
+          photoFile = createImageFile();
+        } catch (IOException ex) {
+          Log.e(TAG, "IOException", ex);
+        }
+        // Continue only if the File was successfully created
+        if (photoFile != null) {
+          takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT,
+                  Uri.fromFile(photoFile));
+          activity.startActivityForResult(takePictureIntent, REQUEST_IMAGE_CAPTURE);
+        }
       }
     }
+  }
+
+  private boolean checkPermissions() {
+    String permissions[] = {android.Manifest.permission.CAMERA, android.Manifest.permission.WRITE_EXTERNAL_STORAGE};
+    boolean grantCamera = ContextCompat.checkSelfPermission(activity, permissions[0]) == PackageManager.PERMISSION_GRANTED;
+    boolean grantExternal = ContextCompat.checkSelfPermission(activity, permissions[1]) == PackageManager.PERMISSION_GRANTED;
+
+    if (!grantCamera && !grantExternal) {
+      ActivityCompat.requestPermissions(activity, permissions, REQUEST_PERMISSION);
+    } else if (!grantCamera) {
+      ActivityCompat.requestPermissions(activity, new String[]{permissions[0]}, REQUEST_PERMISSION);
+    } else if (!grantExternal) {
+      ActivityCompat.requestPermissions(activity, new String[]{permissions[1]}, REQUEST_PERMISSION);
+    }
+
+    return grantCamera && grantExternal;
   }
 
   private File createImageFile() throws IOException {


### PR DESCRIPTION
### Summary

For phones that are running Android 6.0 or higher and the app's target sdk is 23 or higher, then need to implement run time permissions. I was using CameraHelper in a small project and ran into this problem. Now it's abstracted in a way users won't have to worry about handling run time permissions. 

I've also updated the sample application to override 'onRequestPermissionsResult', which if successful, can automatically launch the camera.