### PR TITLE
Remove unnecessary tags from library manifest

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ publish {
   userOrg = 'milbuild'
   groupId = 'com.ibm.watson.developer_cloud'
   artifactId = 'android-sdk'
-  publishVersion = '0.1.0'
+  publishVersion = '0.2.0'
   desc = 'A utility library for use with the Watson Java SDK'
   website = 'https://github.com/watson-developer-cloud/android-sdk'
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -3,9 +3,7 @@
     package="com.ibm.watson.developer_cloud.android.library">
 
   <application
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true">
+      android:label="@string/app_name">
   </application>
 
 </manifest>


### PR DESCRIPTION
Removes `allowBackup` and `supportsRtl`