### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: android
 android:
   components:
   - tools
-  - build-tools-23.0.2
+  - build-tools-26.0.1
   - android-19
   - android-21
   - android-22

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ android:
   - android-22
   - android-23
   - android-24
+  - android-26
   - extra-android-m2repository
   - sys-img-armeabi-v7a-android-19
   - sys-img-armeabi-v7a-android-21


### PR DESCRIPTION
### Summary

The Travis config file was missing some new dependencies to go along with the SDK update that should be present now.