### PR TITLE
Update Bintray upload pattern

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,7 +4,7 @@ commit = True
 tag = True
 
 [bumpversion:file:descriptor.json]
-search = "name": {current_version}
+search = {current_version}
 replace = {new_version}
 
 [bumpversion:file:README.md]

--- a/descriptor.json
+++ b/descriptor.json
@@ -14,7 +14,7 @@
 
   "files": [
     {
-      "uploadPattern": "$1",
+      "uploadPattern": "com/ibm/watson/developer-cloud/android-sdk/0.4.0",
       "includePattern": "library/build/outputs/aar/library-release.aar"
     }
   ],


### PR DESCRIPTION
### Summary

The upload pattern needed to be changed to match the old format to allow it to be used as a dependency.