### PR TITLE
StreamPlayer: better interrupt()

### DIFF
--- a/library/src/main/java/com/ibm/watson/developer_cloud/android/library/audio/StreamPlayer.java
+++ b/library/src/main/java/com/ibm/watson/developer_cloud/android/library/audio/StreamPlayer.java
@@ -78,8 +78,10 @@ public final class StreamPlayer {
    */
   public void interrupt() {
     if (audioTrack != null) {
+      if (audioTrack.getState() == AudioTrack.STATE_INITIALIZED || audioTrack.getState() == AudioTrack.PLAYSTATE_PLAYING) {
+        audioTrack.pause();
+      }
       audioTrack.flush();
-      audioTrack.stop();
       audioTrack.release();
     }
   }


### PR DESCRIPTION
This enhances the StreamPlayer Interrupt method by preventing `IllegalStateException`s being thrown when calling this method while there is no audio playing anymore. 
The `IllegalStateException` occurs when the underlying `AudioTrack` is in an invalid state to perform `pause()`, therefore I'm only calling it when the track is initialized or playing (playing might be enough actually).

I also used `pause()` instead of `stop()` as `pause()` guarantees an immediate stop as described [here](https://developer.android.com/reference/android/media/AudioTrack.html#stop()).