### PR TITLE
Update example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,11 @@ The examples below assume that you already have service credentials. If not, you
 
 #### Getting the Credentials
 
-You will need the `username` and `password` (`api_key` for Visual Recognition) credentials, as well as the `url` for each service. Service credentials are different from your IBM Cloud account username and password.
-
-To get your service credentials, follow these steps:
-
- 1. Log in to IBM Cloud at [https://console.bluemix.net](https://console.bluemix.net).
-
- 1. Create an instance of the service:
-     1. In the IBM Cloud **Catalog**, select the service you want to use.
-     1. Under **Add Service**, type a unique name for the service instance in the Service name field. For example, type `my-service-name`. Leave the default values for the other options.
-     1. Click **Create**.
-
- 1. Copy your credentials:
-     1. On the left side of the page, click **Service Credentials** to view your service credentials.
-     1. Copy `username`, `password`(`api_key` for Visual Recognition), and `url`.
+Since the Android SDK is designed to work with the [Watson Java SDK][java-sdk], getting service credentials works in the same way. You can follow the same instructions for getting those credentials [here](https://github.com/watson-developer-cloud/java-sdk#authentication).
 
 #### Adding the Credentials
 
-The credentials should be added to the `example/res/values/credentials.xml` file shown below.
+Once you've followed the instructions above to get credentials, they should be added to the `example/res/values/credentials.xml` file shown below.
 
 ```xml
 <resources>
@@ -89,9 +76,9 @@ You can also check out the [wiki][wiki] for some additional information.
 
 ## Examples
 
-This SDK is built for use with the [java-sdk][java-sdk].
+This SDK is built for use with the [Watson Java SDK][java-sdk].
 
-The examples below are specific for Android as they use the Microphone and Speaker; for actual services refer to the [java-sdk][java-sdk]. Be sure to use the provided example app as a model for your own Android app using Watson services.
+The examples below are specific for Android as they use the Microphone and Speaker; for actual services refer to the [Java SDK][java-sdk]. You can use the provided example app as a model for your own Android app using Watson services.
 
 ### MicrophoneHelper
 
@@ -136,11 +123,24 @@ Be sure to take a look at the example app to get a working example of putting th
 
 ### StreamPlayer
 
-Provides the ability to directly play an InputStream
+Provides the ability to directly play an `InputStream`. **Note:** The `InputStream` must come from a WAV format audio source.
 
 ```java
 StreamPlayer player = new StreamPlayer();
 player.playStream(yourInputStream);
+```
+
+Since this SDK is intended to be used with the Watson APIs, a typical use case for the `StreamPlayer` class is for playing the output of a Watson Text to Speech call. In that case, you can specify the type of audio file you'd like to receive from the service to ensure it will be output properly by your Android device.
+
+```java
+SynthesizeOptions synthesizeOptions = new SynthesizeOptions.Builder()
+  .text("I love making Android apps")
+  .accept(SynthesizeOptions.Accept.AUDIO_WAV) // specifying that we want a WAV file
+  .build();
+InputStream streamResult = textService.synthesize(synthesizeOptions).execute();
+
+StreamPlayer player = new StreamPlayer();
+player.playStream(streamResult); // should work like a charm
 ```
 
 ### CameraHelper

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Be sure to take a look at the example app to get a working example of putting th
 
 ### StreamPlayer
 
-Provides the ability to directly play an `InputStream`. **Note:** The `InputStream` must come from a WAV format audio source.
+Provides the ability to directly play an `InputStream`. **Note:** The `InputStream` must come from a PCM audio source. Examples include WAV files or Audio/L16.
 
 ```java
 StreamPlayer player = new StreamPlayer();
@@ -141,6 +141,19 @@ InputStream streamResult = textService.synthesize(synthesizeOptions).execute();
 
 StreamPlayer player = new StreamPlayer();
 player.playStream(streamResult); // should work like a charm
+```
+
+Another content type that works from the Text to Speech APIs is the Audio/L16 type. For this you need to specify the sample rate, and you can do so with the alternate version of the `playStream()` method. The default sample rate on the single-argument version is 22050.
+
+```java
+SynthesizeOptions synthesizeOptions = new SynthesizeOptions.Builder()
+  .text("I love making Android apps")
+  .accept("audio/l16;rate=8000") // specifying our content type and sample rate
+  .build();
+InputStream streamResult = textService.synthesize(synthesizeOptions).execute();
+
+StreamPlayer player = new StreamPlayer();
+player.playStream(streamResult, 8000); // passing in the sample rate
 ```
 
 ### CameraHelper

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -43,6 +43,6 @@ dependencies {
   }
   compile 'com.android.support:appcompat-v7:26.0.0'
   compile 'com.android.support:multidex:1.0.1'
-  compile 'com.ibm.watson.developer_cloud:java-sdk:3.9.1'
+  compile 'com.ibm.watson.developer_cloud:java-sdk:6.7.0'
   compile project(':library')
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -43,6 +43,6 @@ dependencies {
   }
   compile 'com.android.support:appcompat-v7:26.0.0'
   compile 'com.android.support:multidex:1.0.1'
-  compile 'com.ibm.watson.developer_cloud:java-sdk:6.7.0'
+  compile 'com.ibm.watson.developer_cloud:java-sdk:6.9.0'
   compile project(':library')
 }

--- a/example/src/main/java/com/ibm/watson/developer_cloud/android/myapplication/MainActivity.java
+++ b/example/src/main/java/com/ibm/watson/developer_cloud/android/myapplication/MainActivity.java
@@ -362,7 +362,7 @@ public class MainActivity extends AppCompatActivity {
       SynthesizeOptions synthesizeOptions = new SynthesizeOptions.Builder()
               .text(params[0])
               .voice(SynthesizeOptions.Voice.EN_US_LISAVOICE)
-              .accept(SynthesizeOptions.Accept.AUDIO_MP3)
+              .accept(SynthesizeOptions.Accept.AUDIO_WAV)
               .build();
       player.playStream(textService.synthesize(synthesizeOptions).execute());
       return "Did synthesize";
@@ -377,7 +377,9 @@ public class MainActivity extends AppCompatActivity {
    * @param grantResults the grant results
    */
   @Override
-  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+  public void onRequestPermissionsResult(int requestCode,
+                                         String[] permissions,
+                                         int[] grantResults) {
     switch (requestCode) {
       case CameraHelper.REQUEST_PERMISSION: {
         // permission granted

--- a/library/src/main/java/com/ibm/watson/developer_cloud/android/library/audio/StreamPlayer.java
+++ b/library/src/main/java/com/ibm/watson/developer_cloud/android/library/audio/StreamPlayer.java
@@ -28,7 +28,6 @@ public final class StreamPlayer {
   private final String TAG = "StreamPlayer";
 
   private AudioTrack audioTrack;
-  private int sampleRate;
 
   private static byte[] convertStreamToByteArray(InputStream is) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -41,22 +40,14 @@ public final class StreamPlayer {
     return baos.toByteArray();
   }
 
-  private static int readInt(final byte[] data, final int offset) {
-    return (data[offset] & 0xff) | ((data[offset + 1] & 0xff) << 8) | ((data[offset + 2] & 0xff) << 16)
-            | (data[offset + 3] << 24); // no 0xff on the last one to keep the sign
-  }
-
   /**
-   * Play the given InputStream.
+   * Play the given InputStream. The stream must have been converted from a WAV type audio source.
    *
-   * @param stream the stream
+   * @param stream the stream derived from a WAV audio source
    */
   public void playStream(InputStream stream) {
     try {
       byte[] data = convertStreamToByteArray(stream);
-      if (data.length > 28) {
-        sampleRate = readInt(data, 24);
-      }
       int headSize = 44, metaDataSize = 48;
       int destPos = headSize + metaDataSize;
       int rawLength = data.length - destPos;
@@ -78,7 +69,8 @@ public final class StreamPlayer {
    */
   public void interrupt() {
     if (audioTrack != null) {
-      if (audioTrack.getState() == AudioTrack.STATE_INITIALIZED || audioTrack.getState() == AudioTrack.PLAYSTATE_PLAYING) {
+      if (audioTrack.getState() == AudioTrack.STATE_INITIALIZED
+              || audioTrack.getState() == AudioTrack.PLAYSTATE_PLAYING) {
         audioTrack.pause();
       }
       audioTrack.flush();
@@ -91,11 +83,27 @@ public final class StreamPlayer {
    */
   private void initPlayer() {
     synchronized (this) {
-      int bs = AudioTrack.getMinBufferSize(sampleRate, AudioFormat.CHANNEL_OUT_MONO, AudioFormat.ENCODING_PCM_16BIT);
-      audioTrack = new AudioTrack(AudioManager.STREAM_MUSIC, sampleRate, AudioFormat.CHANNEL_OUT_MONO,
-              AudioFormat.ENCODING_PCM_16BIT, bs, AudioTrack.MODE_STREAM);
-      if (audioTrack != null)
-        audioTrack.play();
+      // default sample rate for .wav from Watson TTS
+      // see https://console.bluemix.net/docs/services/text-to-speech/http.html#format
+      final int DEFAULT_SAMPLE_RATE = 22050;
+
+      int bufferSize = AudioTrack.getMinBufferSize(
+              DEFAULT_SAMPLE_RATE,
+              AudioFormat.CHANNEL_OUT_MONO,
+              AudioFormat.ENCODING_PCM_16BIT);
+      if (bufferSize == AudioTrack.ERROR_BAD_VALUE) {
+        throw new RuntimeException("Could not determine buffer size for audio");
+      }
+
+      audioTrack = new AudioTrack(
+              AudioManager.STREAM_MUSIC,
+              DEFAULT_SAMPLE_RATE,
+              AudioFormat.CHANNEL_OUT_MONO,
+              AudioFormat.ENCODING_PCM_16BIT,
+              bufferSize,
+              AudioTrack.MODE_STREAM
+      );
+      audioTrack.play();
     }
   }
 }


### PR DESCRIPTION
This PR updates the example app to use the newest version of the Java SDK right now: 6.9.0.

Along with this, the `StreamPlayer` class has been tweaked to explicitly handle PCM-type `InputStream`s only. This is due to the implementation with [Android's `AudioTrack` class](https://developer.android.com/reference/android/media/AudioTrack), which only handles PCM audio. 

Of the return types for Watson Text to Speech, only `audio/l16;rate={rate}` and `audio/wav` work with this. To fully support the former type, an overloaded version of `playStream()` has been added to support a custom sample rate. Method documentation and the main README have also been updated to explain this.