### PR TITLE
Use unique file provider in library code

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -6,8 +6,8 @@
       android:label="@string/app_name">
 
     <provider
-        android:name="android.support.v4.content.FileProvider"
-        android:authorities="com.ibm.watson.developer_cloud.android.provider"
+        android:name=".util.WatsonFileProvider"
+        android:authorities="${applicationId}.com.ibm.watson.developer_cloud.android.provider"
         android:exported="false"
         android:grantUriPermissions="true">
       <meta-data

--- a/library/src/main/java/com/ibm/watson/developer_cloud/android/library/util/WatsonFileProvider.java
+++ b/library/src/main/java/com/ibm/watson/developer_cloud/android/library/util/WatsonFileProvider.java
@@ -1,0 +1,9 @@
+package com.ibm.watson.developer_cloud.android.library.util;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * Trivial subclass of FileProvider to avoid provider authority collisions.
+ * See https://commonsware.com/blog/2017/06/27/fileprovider-libraries.html for more info.
+ */
+public class WatsonFileProvider extends FileProvider { }


### PR DESCRIPTION
Fixes #79 

Previously, there would be an issue when multiple apps on the same device were using this library, since they would have matching `FileProvider` authority strings, which need to be unique.

Adding the `${applicationId}` variable, as suggested in the issue, wasn't quite enough. [This blog post](https://commonsware.com/blog/2017/06/27/fileprovider-libraries.html) and [this StackOverflow post](https://stackoverflow.com/questions/43175014/possible-to-use-multiple-authorities-with-fileprovider/43444164#43444164) help explain how this solution came about.