### PR TITLE
Fix errors when closing microphone capture thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
 - ./gradlew generateSourcesJar
 - ./gradlew generatePomFileForAarPublication
 - ./gradlew generateReleaseJavadoc
+- ./gradlew library:assemble
 - echo no | android create avd --force -n test -t $API --abi $ABI
 - emulator -avd test -no-skin -no-audio -no-window &
 - android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,13 @@ deploy:
     tags: true
     repo: watson-developer-cloud/android-sdk
     condition: "$API = android-19"
+- provider: script
+  script: ".utility/push-javadoc-to-gh-pages.sh"
+  skip_cleanup: true
+  on:
+    branch: master
+    repo: watson-developer-cloud/android-sdk
+    condition: "$API = android-19"
 - provider: bintray
   file: $TRAVIS_BUILD_DIR/descriptor.json
   user: milbuild

--- a/.utility/push-javadoc-to-gh-pages.sh
+++ b/.utility/push-javadoc-to-gh-pages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_REPO_SLUG" == "watson-developer-cloud/android-sdk" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ] && [ "$TRAVIS_BUILD_NUMBER.1" == "$TRAVIS_JOB_NUMBER" ]; then
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
 
   git config --global user.email "wps@us.ibm.com"
   git config --global user.name "Watson Github Bot"

--- a/library/src/main/java/com/ibm/watson/developer_cloud/android/library/audio/MicrophoneInputStream.java
+++ b/library/src/main/java/com/ibm/watson/developer_cloud/android/library/audio/MicrophoneInputStream.java
@@ -106,9 +106,9 @@ public final class MicrophoneInputStream extends InputStream implements AudioCon
    */
   @Override
   public void close() throws IOException {
+    captureThread.end();
     os.close();
     is.close();
-    captureThread.end();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/watson-developer-cloud/java-sdk/issues/1099

This PR shifts the order of operations in the `close()` method of `MicrophoneInputStream` to prevent unnecessary error logs when manually closing a stream. With the old order, there were many cases where the `captureThread` would try to read information in between closing the `PipedInputStream` and `PipedOutputStream` references and getting to close the `captureThread`, resulting in warnings.

In addition, I made some small CI changes to ensure the release artifacts are built during CI and that the Javadoc release works properly.